### PR TITLE
perf: resolve stacktrace paths using workspace folder segment

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -114,9 +114,15 @@ Reusable building blocks for composing tokenizers:
 - `lineAndColumn` — `:123:45`, `(123)`, `?:line 123`, etc.
 - `re` — tagged template function for composing regexes from primitives
 
-### `getPossibleFilePathsToSearch`
+### File path resolution (`workspaceFileResolver.ts`)
 
-For a path `a/b/c/file.ts` generates `a/b/c/file.ts`, `b/c/file.ts`, `c/file.ts`, `file.ts` — used to find a file in the workspace when the stack trace contains a partial path.
+`VscodeWorkspaceFileSearcher` resolves a `filePath` from a token to an absolute URI in the workspace. The search strategy, in order:
+
+1. **Smart candidates** (`computeSmartCandidatePaths`) — looks for a workspace folder's on-disk directory name among the path segments. If found, constructs the URI directly with `vscode.Uri.joinPath(folder.uri, suffix)` and checks existence via `workspace.fs.stat()` — a single fast call, no glob search. Example: workspace folder `my-repo` at `/home/user/my-repo`, path `C:/BuildAgent/work/hash/my-repo/src/Utils/Helper.cs` → stats `/home/user/my-repo/src/Utils/Helper.cs` directly.
+
+2. **All suffix candidates** (`getPossibleFilePathsToSearch`) — fallback. For `a/b/c/file.ts` generates `a/b/c/file.ts`, `b/c/file.ts`, `c/file.ts`, `file.ts` and tries each in order. For each candidate, two `workspace.findFiles()` calls are made: an exact match, then a wildcard-prefix match (`**/*/<candidate>`).
+
+`computeSmartCandidatePaths` lives in `workspaceFileResolver.ts` — takes `filePath` and workspace folders, then returns candidate `vscode.Uri` values built with `vscode.Uri.joinPath()`. Tested in `src/test/computeSmartCandidatePaths.test.ts`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
 		}
 	},
 	"scripts": {
-		"build": "tsc; copyfiles --flat src/webview/client/*.css out/webview/client",
+		"build": "tsc && copyfiles --flat src/webview/client/*.css out/webview/client",
 		"test": "vitest run",
 		"vscode:prepublish": "npm run build"
 	},

--- a/src/test/computeSmartCandidatePaths.test.ts
+++ b/src/test/computeSmartCandidatePaths.test.ts
@@ -1,0 +1,126 @@
+import { vi } from "vitest";
+import { computeSmartCandidatePaths } from "../workspaceFileResolver";
+
+vi.mock("vscode", () => ({
+    Uri: {
+        joinPath: (uri: { path: string }, path: string) => ({ path: uri.path + "/" + path }),
+    },
+}));
+
+function computeSmartCandidatePathStrings(
+    filePath: string,
+    folders: ReadonlyArray<{ uriPath: string }>
+): string[] {
+    return computeSmartCandidatePaths(
+        filePath,
+        folders.map(folder => ({ uri: { path: folder.uriPath } as any }))
+    ).map(uri => (uri as any).path);
+}
+
+describe("computeSmartCandidatePaths", () => {
+    test("returns absolute path when folder name matches path segment", () => {
+        const result = computeSmartCandidatePathStrings(
+            "/ci/build/my-repo/src/Utils/Helper.cs",
+            [{ uriPath: "/home/user/my-repo" }]
+        );
+        expect(result).toEqual(["/home/user/my-repo/src/Utils/Helper.cs"]);
+    });
+
+    test("returns empty array when no folders", () => {
+        const result = computeSmartCandidatePathStrings(
+            "/ci/build/my-repo/src/Utils/Helper.cs",
+            []
+        );
+        expect(result).toEqual([]);
+    });
+
+    test("returns empty array when folder name not found in path", () => {
+        const result = computeSmartCandidatePathStrings(
+            "/ci/build/my-repo/src/Utils/Helper.cs",
+            [{ uriPath: "/home/user/other-project" }]
+        );
+        expect(result).toEqual([]);
+    });
+
+    test("is case-insensitive", () => {
+        const result = computeSmartCandidatePathStrings(
+            "C:/BuildAgent/work/hash/My-Repo/src/Utils/Helper.cs",
+            [{ uriPath: "/home/user/my-repo" }]
+        );
+        expect(result).toEqual(["/home/user/my-repo/src/Utils/Helper.cs"]);
+    });
+
+    test("handles backslash separators in file path", () => {
+        const result = computeSmartCandidatePathStrings(
+            "C:\\BuildAgent\\work\\hash\\my-repo\\src\\Utils\\Helper.cs",
+            [{ uriPath: "/home/user/my-repo" }]
+        );
+        expect(result).toEqual(["/home/user/my-repo/src/Utils/Helper.cs"]);
+    });
+
+    test("handles multiple folders, returns match for the correct one", () => {
+        const result = computeSmartCandidatePathStrings(
+            "/ci/build/repo-b/src/Utils/Helper.cs",
+            [
+                { uriPath: "/home/user/repo-a" },
+                { uriPath: "/home/user/repo-b" },
+            ]
+        );
+        expect(result).toEqual(["/home/user/repo-b/src/Utils/Helper.cs"]);
+    });
+
+    test("handles folder name appearing multiple times in path", () => {
+        const result = computeSmartCandidatePathStrings(
+            "/ci/foo/foo/foo/src/Helper.cs",
+            [{ uriPath: "/home/user/foo" }]
+        );
+        expect(result).toEqual([
+            "/home/user/foo/foo/foo/src/Helper.cs",
+            "/home/user/foo/foo/src/Helper.cs",
+            "/home/user/foo/src/Helper.cs",
+        ]);
+    });
+
+    test("does not return candidate when folder name matches only the last segment", () => {
+        const result = computeSmartCandidatePathStrings(
+            "/ci/build/my-repo",
+            [{ uriPath: "/home/user/my-repo" }]
+        );
+        expect(result).toEqual([]);
+    });
+
+    describe("Windows paths", () => {
+        // On Windows `vscode.Uri.path` carries a leading slash and drive letter, e.g. `/c:/Users/user/my-repo`.
+        test("resolves a backslash build-agent path against a Windows folder uri", () => {
+            const result = computeSmartCandidatePathStrings(
+                "C:\\BuildAgent\\work\\a1b2c3\\my-repo\\src\\Utils\\Helper.cs",
+                [{ uriPath: "/c:/Users/user/my-repo" }]
+            );
+            expect(result).toEqual(["/c:/Users/user/my-repo/src/Utils/Helper.cs"]);
+        });
+
+        test("matches case-insensitively when the agent path casing differs from the folder", () => {
+            const result = computeSmartCandidatePathStrings(
+                "C:\\agent\\_work\\1\\s\\myrepo\\src\\App.cs",
+                [{ uriPath: "/c:/Projects/MyRepo" }]
+            );
+            expect(result).toEqual(["/c:/Projects/MyRepo/src/App.cs"]);
+        });
+
+        test("handles mixed forward and backslashes in one path", () => {
+            const result = computeSmartCandidatePathStrings(
+                "C:\\BuildAgent\\work/a1b2c3\\my-repo/src\\Helper.cs",
+                [{ uriPath: "/c:/Users/user/my-repo" }]
+            );
+            expect(result).toEqual(["/c:/Users/user/my-repo/src/Helper.cs"]);
+        });
+
+        test("handles a UNC network path", () => {
+            const result = computeSmartCandidatePathStrings(
+                "\\\\build-server\\share\\my-repo\\src\\Helper.cs",
+                [{ uriPath: "/c:/Users/user/my-repo" }]
+            );
+            expect(result).toEqual(["/c:/Users/user/my-repo/src/Helper.cs"]);
+        });
+    });
+});

--- a/src/workspaceFileResolver.ts
+++ b/src/workspaceFileResolver.ts
@@ -9,6 +9,25 @@ export interface FileSearcher {
 
 export class VscodeWorkspaceFileSearcher implements FileSearcher {
     async findFile(filePath: string, cancellationToken: vscode.CancellationToken, progress: IProgressReporter): Promise<string | undefined> {
+        const folders = vscode.workspace.workspaceFolders ?? [];
+        const smartPaths = computeSmartCandidatePaths(filePath, folders);
+
+        // Smart candidates: construct absolute URI directly, no findFiles needed
+        for (const smartPath of smartPaths) {
+            if (cancellationToken.isCancellationRequested) {
+                progress.complete();
+                return undefined;
+            }
+            try {
+                await vscode.workspace.fs.stat(smartPath);
+                progress.complete();
+                return smartPath.fsPath;
+            } catch {
+                // file doesn't exist at this path, try next
+            }
+        }
+
+        // Fallback: findFiles for all suffix candidates
         const possibleFilePaths = Array.from(getPossibleFilePathsToSearch(filePath));
         const splitter = new ProgressSplitter(progress);
         const candidateProgresses = possibleFilePaths.map(() => splitter.createChild());
@@ -26,7 +45,7 @@ export class VscodeWorkspaceFileSearcher implements FileSearcher {
             if (uris1.length > 0) {
                 candidateProgress.complete();
                 progress.complete();
-                return uris1[0]!.path;
+                return uris1[0]!.fsPath;
             }
 
             const uris2 = await vscode.workspace.findFiles(
@@ -38,12 +57,33 @@ export class VscodeWorkspaceFileSearcher implements FileSearcher {
             candidateProgress.complete();
             if (uris2.length > 0) {
                 progress.complete();
-                return uris2[0]!.path;
+                return uris2[0]!.fsPath;
             }
         }
         progress.complete();
         return undefined;
     }
+}
+
+export function computeSmartCandidatePaths(
+    filePath: string,
+    folders: ReadonlyArray<{ uri: vscode.Uri }>
+): vscode.Uri[] {
+    const parts = filePath.split(/[\/\\]/);
+    const results: vscode.Uri[] = [];
+    for (const folder of folders) {
+        // The directory's on-disk basename is what appears in a stack-trace path from a
+        // build agent — a folder's VSCode display name is a UI-only label that never does.
+        const uriSegments = folder.uri.path.split("/").filter(segment => segment.length > 0);
+        const folderName = uriSegments[uriSegments.length - 1]?.toLowerCase();
+        if (folderName == undefined) continue;
+        for (let i = 0; i < parts.length - 1; i++) {
+            if (parts[i]!.toLowerCase() === folderName) {
+                results.push(vscode.Uri.joinPath(folder.uri, parts.slice(i + 1).join("/")));
+            }
+        }
+    }
+    return results;
 }
 
 export async function enrichTokensWithWorkspacePaths(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "module": "CommonJS",
     "lib": ["ES2020", "DOM"],
-    "types": ["vitest/globals"],
+    "types": ["vitest/globals", "vscode-webview"],
     "outDir": "./out",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
## Summary

Adds a fast path for resolving stack-trace file paths without running a full `workspace.findFiles("**/*/<suffix>")` glob in the common case.

## Details

For build-agent paths like `C:\BuildAgent\work\<hash>\my-repo\src\Helper.cs`, the resolver now tries to find the workspace folder's real directory name in the path, builds a candidate URI with `Uri.joinPath`, and verifies it with a single `fs.stat()`.

If that does not work, it falls back to the existing `findFiles` search.

Also fixes Windows path handling by using `Uri.fsPath` instead of `Uri.path`, since `openTextDocument` and `git.repository.log({ path })` expect OS-native paths.

## Tests / misc

Added tests for matching, case-insensitivity, fallback, Windows/UNC paths. Also updated the build script, added `vscode-webview` types, and documented the strategy in `ARCHITECTURE.md`.
