### PR TITLE
fix: keep stack trace panel scroll position when opening a link

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,8 @@ export function activate(context: vscode.ExtensionContext) {
         resolveWebviewView: (webviewView: vscode.WebviewView) => {
             controller.setWebView(webviewView);
         },
+    }, {
+        webviewOptions: { retainContextWhenHidden: true },
     }));
     
     controller.init();

--- a/src/webview/client/webview.css
+++ b/src/webview/client/webview.css
@@ -3,8 +3,20 @@
     white-space: pre-wrap;
 }
 
+.file-path {
+    color: var(--vscode-textLink-foreground);
+    cursor: pointer;
+    text-decoration: none;
+}
+
+.file-path:hover {
+    color: var(--vscode-textLink-activeForeground);
+    text-decoration: underline;
+}
+
 .symbol {
     color: inherit;
+    cursor: pointer;
     text-decoration: none;
 }
 

--- a/src/webview/client/webview.ts
+++ b/src/webview/client/webview.ts
@@ -90,8 +90,8 @@ function showLines(lines: Token[][]) {
             let tokenElement;
             if (token[1]?.type == "FilePath") {
                 tokenElement = document.createElement("a");
+                tokenElement.classList.add("file-path");
                 tokenElement.innerText = tokenText;
-                tokenElement.href = "#";
 
                 const lastCommit = token[1]?.vcsInfo?.lastChangeCommit;
                 if (lastCommit && lastCommit.authorDate) {
@@ -118,7 +118,6 @@ function showLines(lines: Token[][]) {
                 tokenElement = document.createElement("a");
                 tokenElement.classList.add("symbol");
                 tokenElement.innerText = tokenText;
-                tokenElement.href = "#";
                 tokenElement.onclick = event => {
                     vscode.postMessage({
                         type: "GoToSymbol",


### PR DESCRIPTION
Clicking a file or symbol in the stack trace panel used to scroll the webview back to the top, so users lost their place in long stack traces.

Root cause: file and symbol actions were rendered as `<a href="#">`. In a VS Code webview, activating the `#` fragment can reset the scroll position to the top, and the existing `onclick` handler was not enough to prevent that behavior.

Fix: remove `href="#"` from file and symbol links while keeping the existing click handlers, and add CSS to preserve the clickable appearance: link color and pointer cursor.
